### PR TITLE
Cli security bug 1.8.7

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -214,3 +214,9 @@
 
 - fix accidental pre-merge publish
 
+
+latest
+------
+
+- fix cli startup missing browser_primus
+- fix cli backward compat for config with `dataLayer` vs. `datalayer`

--- a/bin/happner
+++ b/bin/happner
@@ -48,14 +48,6 @@ try {
   console.log('INFO: created directory ' + happnerHome);
 }
 
-// Primus compiles their script, need write permission
-// Only necessary for global install
-
-// Happn uses this if defined.
-
-process.env.PRIMUS_SCRIPT = happnHome + '/js/browser_primus.js';
-
-
 var config = {
   name: 'home', // <------- your localnode
   version: '0.0.1',

--- a/lib/system/datalayer.js
+++ b/lib/system/datalayer.js
@@ -39,7 +39,12 @@ module.exports.create = function(mesh, config, callback) {
     }
   );
 
-  config.datalayer = config.datalayer || config.dataLayer || {};
+  config.datalayer = config.datalayer || {};
+  if (config.dataLayer) {
+    Object.keys(config.dataLayer).forEach(function(key) {
+      config.datalayer[key] = config.dataLayer[key];
+    });
+  }
   delete config.dataLayer;
 
   if (typeof config.port !== 'undefined') {

--- a/lib/system/packager.js
+++ b/lib/system/packager.js
@@ -1,9 +1,13 @@
+// TODO: This is expensive... minifies and gzips a set of scripts !! at every startup...
+//       to provide single /client/api script to browser.
+//       Better if this was cached to disk (when in production mode)
+
 // BUG: more than one meshnode in same process and packager does not apply
 // post-start changes to script package into all mesh nodes.
 
 // A preliminary work toward asset packaging (minify, gzip, etag, etc.)
 // The ideal would be a per component widget assembly line.
-// Allows for serving individual scripts development. 
+// Allows for serving individual scripts development.
 // This one packages only the core /client/api script from ./api.js and it's dependancies
 // Make it not do all this on every startup.
 
@@ -26,7 +30,7 @@ function Packager(mesh) {
   mesh.tools.packages = this.packages = {};
 
   var script1 = dirname(dirname(require.resolve('bluebird'))) + '/browser/bluebird.js';
-  var script2 = normalize(process.env.PRIMUS_SCRIPT || mesh._mesh.datalayer.server.services.pubsub.script);
+  var script2 = normalize(mesh._mesh.datalayer.server.services.pubsub.script);
   var script3 = dirname(require.resolve('happn')) + '/client/base.js';
   var script4 = normalize(__dirname + '/shared/logger.js');
   var script5 = normalize(__dirname + '/shared/promisify.js');
@@ -113,7 +117,7 @@ Packager.prototype.initialize = function(callback) {
   })
 
   // TODO: Watch where necessary...
-  //   In non production mode, it would 
+  //   In non production mode, it would
   //   be ideal if changes to the component scripts
   //   were detected, averting the need to restart the
   //   server to get the updated script to the browser.
@@ -186,7 +190,7 @@ Packager.prototype.assemble = function() {
   var gzip = Promise.promisify(zlib.gzip);
 
   return new Promise(function(resolve, reject) {
-    
+
     _this.merged.script = '';
 
     _this.scripts.forEach(function(script) {
@@ -218,7 +222,7 @@ Packager.prototype.assemble = function() {
       Object.defineProperty(_this.packages, 'api', {
         get: function() {
           return _this.merged;
-        }, 
+        },
         enumerable: true,
         configurable: true,
       });

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "diskspace": "0.1.7",
     "fs-extra": "0.24.0",
     "glob": "5.0.15",
-    "happn": "2.6.5",
+    "happn": "2.7.0",
     "happn-logger": "0.0.2",
     "happner-terminal": "0.0.7",
     "md5": "2.0.0",


### PR DESCRIPTION
The problem was caused by me renaming the expected config key from `dataLayer` to `datalayer`. It was backward compatible but not for the case where both were defined - as it is when using the cli (which creates `datalayer`) + external config creating `dataLayer`

Changing the external config to `datalayer` would have fixed the problem.

This pull request fixes the backward compatibility issue with the cli as well as the missing browser_primus script.