### PR TITLE
Issue #176

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -321,3 +321,8 @@
 -----------------
 
 - prevent crash due to unresolved issue #172
+
+1.18.0 2016-08-16
+-----------------
+
+- Allow module function called over the exchange to return a promise.

--- a/lib/system/component-instance.js
+++ b/lib/system/component-instance.js
@@ -394,7 +394,7 @@ ComponentInstance.prototype._loadModule = function (module) {
           }
 
           var callbackProxy = function () {
-            if (callbackCalled) return _this.log.error('Callback for %s called twice', methodName);
+            if (callbackCalled) return _this.log.error('Callback invoked more than once for method %s', methodName);
             callbackCalled = true;
             callback(null, Array.prototype.slice.apply(arguments));
           };

--- a/lib/system/component-instance.js
+++ b/lib/system/component-instance.js
@@ -412,7 +412,7 @@ ComponentInstance.prototype._loadModule = function (module) {
 
         var returnObject = methodDefn.apply(_this.module.instance, parameters);
 
-        if (callbackIndex == -1 && returnObject && typeof returnObject.then == 'function') {
+        if (callbackIndex == -1 && utilities.isPromise(returnObject)) {
           returnObject
             .then(function (result) {
               if (callbackProxy) callbackProxy(null, result);

--- a/lib/system/component-instance.js
+++ b/lib/system/component-instance.js
@@ -349,6 +349,8 @@ ComponentInstance.prototype._loadModule = function (module) {
   Object.defineProperty(this, 'operate', {
     value: function (methodName, parameters, callback, origin) {
       try {
+        var callbackIndex = -1;
+        var callbackCalled = false;
 
         _this.stats.component[_this.name].calls++;
 
@@ -373,8 +375,8 @@ ComponentInstance.prototype._loadModule = function (module) {
 
         if (callback) {
 
-          if (methodSchema.type == 'sync-promise'){
-            try{
+          if (methodSchema.type == 'sync-promise') {
+            try {
 
               if (typeof methodDefn.$happnSeq !== 'undefined') parameters.splice(methodDefn.$happnSeq, 0, _this);
 
@@ -382,21 +384,20 @@ ComponentInstance.prototype._loadModule = function (module) {
 
               var result = methodDefn.apply(_this.module.instance, parameters);
               return callback(null, [null, result]);
-            }catch(e){
+            } catch (e) {
               return callback(null, [e]);
             }
           }
 
-          callbackIndex = -1;
-
           for (var i in methodSchema.parameters) {
             if (methodSchema.parameters[i].type == 'callback') callbackIndex = i
           }
-          ;
 
           var callbackProxy = function () {
+            if (callbackCalled) return _this.log.error('Callback for %s called twice', methodName);
+            callbackCalled = true;
             callback(null, Array.prototype.slice.apply(arguments));
-          }
+          };
 
           if (callbackIndex == -1) {
             parameters.push(callbackProxy)
@@ -409,7 +410,15 @@ ComponentInstance.prototype._loadModule = function (module) {
 
         if (typeof methodDefn.$originSeq !== 'undefined') parameters.splice(methodDefn.$originSeq, 0, origin);
 
-        methodDefn.apply(_this.module.instance, parameters);
+        var returnObject = methodDefn.apply(_this.module.instance, parameters);
+
+        if (callbackIndex == -1 && returnObject && returnObject.then) {
+          returnObject
+            .then(function (result) {
+              callbackProxy(null, result);
+            })
+            .catch(callbackProxy);
+        }
 
       } catch (e) {
 
@@ -643,7 +652,7 @@ ComponentInstance.prototype._attach = function (config, mesh, callback) {
       this.log.error("Failure to attach web methods", e);
       return callback(e);
     }
-  };
+  }
 
   var listenAddress = '/_exchange/requests/' + this.info.mesh.name + '/' + this.name + '/';
   var subscribeMask = listenAddress + '*';

--- a/lib/system/component-instance.js
+++ b/lib/system/component-instance.js
@@ -412,12 +412,14 @@ ComponentInstance.prototype._loadModule = function (module) {
 
         var returnObject = methodDefn.apply(_this.module.instance, parameters);
 
-        if (callbackIndex == -1 && returnObject && returnObject.then) {
+        if (callbackIndex == -1 && returnObject && typeof returnObject.then == 'function') {
           returnObject
             .then(function (result) {
-              callbackProxy(null, result);
+              if (callbackProxy) callbackProxy(null, result);
             })
-            .catch(callbackProxy);
+            .catch(function (err) {
+              if (callbackProxy) callbackProxy(err);
+            });
         }
 
       } catch (e) {

--- a/lib/system/shared/messenger.js
+++ b/lib/system/shared/messenger.js
@@ -390,7 +390,7 @@
       }
     });
 
-    // if the method is sync on the other side with no result expected, we don't decalre a callback handler
+    // if the method is sync on the other side with no result expected, we don't create a callback handler
     if (args.length > 0 && methodDescription.type != 'sync' &&
       typeof args[args.length - 1] == 'function' && !_this.responseHandlers[message.callbackAddress]) {
       _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[args.length - 1], message);

--- a/lib/system/shared/messenger.js
+++ b/lib/system/shared/messenger.js
@@ -316,14 +316,13 @@
     }
   };
 
-  Messenger.prototype.__createCallbackHandler = function (actualHandler, message, timeout) {
+  Messenger.prototype.__createCallbackHandler = function (actualHandler, message) {
 
     var _this = this;
 
     var callbackHandler = {
       "handler": actualHandler,
-      "callbackAddress": message.callbackAddress,
-      "timeout":timeout
+      "callbackAddress": message.callbackAddress
     };
 
     callbackHandler.handleResponse = function (argumentsArray) {
@@ -341,9 +340,8 @@
     }.bind(callbackHandler);
 
     callbackHandler.timedout = setTimeout(function () {
-      var reportTimeout = _this.responseHandlers[this.callbackAddress] ? _this.responseHandlers[this.callbackAddress].timeout : true;
       delete _this.responseHandlers[this.callbackAddress];
-      if (reportTimeout) return this.handler("Request timed out");
+      return this.handler("Request timed out");
 
     }.bind(callbackHandler), _this._endpoint.description.setOptions.timeout || 10000);
 
@@ -382,7 +380,7 @@
           throw new MeshError('Invalid callback for ' + address + ', callback must be a function');
 
 
-        _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[index], message, true);
+        _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[index], message);
 
       }
       else if (args.length >= index + 1) {
@@ -392,14 +390,10 @@
       }
     });
 
-    // if this method is synchronous on the other side of the exchange, we take our promise's callback and use it to wait
-    if (args.length > 0 && methodDescription.type == 'sync-promise' && typeof args[args.length - 1] == 'function'){
-      _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[args.length - 1], message, true);
-    }
-    // We do this for all other cases for if the other side returns a promise
-    // we do not know if this is the case, so we can't time out if this happens
-    if (args.length > 0 && typeof args[args.length - 1] == 'function' && !_this.responseHandlers[message.callbackAddress]) {
-      _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[args.length - 1], message, false);
+    // if the method is sync on the other side with no result expected, we don't decalre a callback handler
+    if (args.length > 0 && methodDescription.type != 'sync' &&
+      typeof args[args.length - 1] == 'function' && !_this.responseHandlers[message.callbackAddress]) {
+      _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[args.length - 1], message);
     }
 
     return callback(null, message);

--- a/lib/system/shared/messenger.js
+++ b/lib/system/shared/messenger.js
@@ -316,13 +316,14 @@
     }
   };
 
-  Messenger.prototype.__createCallbackHandler = function(actualHandler, message){
+  Messenger.prototype.__createCallbackHandler = function (actualHandler, message, timeout) {
 
     var _this = this;
 
     var callbackHandler = {
       "handler": actualHandler,
-      "callbackAddress": message.callbackAddress
+      "callbackAddress": message.callbackAddress,
+      "timeout":timeout
     };
 
     callbackHandler.handleResponse = function (argumentsArray) {
@@ -340,9 +341,9 @@
     }.bind(callbackHandler);
 
     callbackHandler.timedout = setTimeout(function () {
-
+      var reportTimeout = _this.responseHandlers[this.callbackAddress] ? _this.responseHandlers[this.callbackAddress].timeout : true;
       delete _this.responseHandlers[this.callbackAddress];
-      return this.handler("Request timed out");
+      if (reportTimeout) return this.handler("Request timed out");
 
     }.bind(callbackHandler), _this._endpoint.description.setOptions.timeout || 10000);
 
@@ -381,7 +382,7 @@
           throw new MeshError('Invalid callback for ' + address + ', callback must be a function');
 
 
-        _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[index], message);
+        _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[index], message, true);
 
       }
       else if (args.length >= index + 1) {
@@ -391,9 +392,14 @@
       }
     });
 
-    //if this method is synchronous on the other side of the exchange, we take our promise's callback and use it to wait
+    // if this method is synchronous on the other side of the exchange, we take our promise's callback and use it to wait
     if (args.length > 0 && methodDescription.type == 'sync-promise' && typeof args[args.length - 1] == 'function'){
-      _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[args.length - 1], message);
+      _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[args.length - 1], message, true);
+    }
+    // We do this for all other cases for if the other side returns a promise
+    // we do not know if this is the case, so we can't time out if this happens
+    if (args.length > 0 && typeof args[args.length - 1] == 'function' && !_this.responseHandlers[message.callbackAddress]) {
+      _this.responseHandlers[message.callbackAddress] = _this.__createCallbackHandler(args[args.length - 1], message, false);
     }
 
     return callback(null, message);

--- a/lib/system/utilities.js
+++ b/lib/system/utilities.js
@@ -5,7 +5,7 @@ var shortId = require('shortid')
   , Promise = require('bluebird')
   , glob = Promise.promisify(require("glob"))
   , Logger = require('happn-logger')
-;
+  ;
 // var depwarned0 = false;
 var depwarned1 = false;
 var depwarned2 = false;
@@ -178,3 +178,7 @@ module.exports.findFiles = function (patterns, opts, callback) {
   }).catch(callback);
 
 };
+
+module.exports.isPromise = function (promise) {
+  return (promise && typeof promise.then === 'function' && typeof promise.catch === 'function')
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happner",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "distributed application engine with evented storage and mesh services",
   "main": "lib/mesh.js",
   "bin": {

--- a/test/a8-exchange-promises.js
+++ b/test/a8-exchange-promises.js
@@ -52,7 +52,7 @@ SeeAbove.prototype.promiseReturnAsIs = function (opts) {
 };
 
 SeeAbove.prototype.promiseReturner = Promise.promisify(function (opts, callback) {
-  return this.promiseMethod(opts, callback);
+  this.promiseMethod(opts, callback);
 });
 
 SeeAbove.prototype.synchronousMethodHappnOrigin = function (opts, opts2, $happn, $origin) {
@@ -321,13 +321,11 @@ describe('a8 - exchange supports promises', function () {
 
     this.timeout(1500);
 
-    var promise = this.mesh.exchange.component.promiseReturnAsIs({number: 1})
+    this.mesh.exchange.component.promiseReturnAsIs({number: 1})
       .then(function (res) {
         res.should.eql({number: 2});
         done();
       });
-
-    return promise;
 
   });
 

--- a/test/a8-exchange-promises.js
+++ b/test/a8-exchange-promises.js
@@ -16,6 +16,10 @@ SeeAbove.prototype.methodName1 = function (opts, callback) {
   callback(null, opts);
 };
 
+SeeAbove.prototype.fireAndForget = function(opts) {
+  //do nothing
+};
+
 SeeAbove.prototype.promiseMethod = Promise.promisify(function (opts, callback) {
 
   if (opts.errorAs == 'callback') return callback(new Error('THIS IS JUST A TEST'));
@@ -110,8 +114,13 @@ describe('a8 - exchange supports promises', function () {
     mesh = this.mesh = new Mesh();
 
     mesh.initialize({
+      dataLayer:{
+        setOptions:{
+          timeout:1000
+        }
+      },
       util: {
-        // logger: {}
+        logLevel: 'trace'
       },
       modules: {
         'component': {
@@ -321,11 +330,33 @@ describe('a8 - exchange supports promises', function () {
 
     this.timeout(1500);
 
-    this.mesh.exchange.component.promiseReturnAsIs({number: 1})
+    var promise = this.mesh.exchange.component.promiseReturnAsIs({number: 1})
+
+    promise
       .then(function (res) {
         res.should.eql({number: 2});
         done();
+      })
+      .catch(function(err){
+        done(err);
       });
+
+  });
+
+  it('does not time out a sync function', function (done) {
+
+    this.timeout(2500);
+
+    this.mesh.exchange.component.fireAndForget({number: 1})
+      .then(function (res) {
+        // should never get here
+        throw('Should not get a result');
+      })
+      .catch(function(err){
+        done(err);
+      });
+
+    setTimeout(done,2000);
 
   });
 

--- a/test/a8-exchange-promises.js
+++ b/test/a8-exchange-promises.js
@@ -51,13 +51,9 @@ SeeAbove.prototype.promiseCaller = function (opts, callback) {
 
 };
 
-SeeAbove.prototype.promiseReturnAsIs = function (opts) {
+SeeAbove.prototype.promiseReturner = function (opts) {
   return this.promiseMethod(opts);
 };
-
-SeeAbove.prototype.promiseReturner = Promise.promisify(function (opts, callback) {
-  this.promiseMethod(opts, callback);
-});
 
 SeeAbove.prototype.synchronousMethodHappnOrigin = function (opts, opts2, $happn, $origin) {
 
@@ -318,28 +314,10 @@ describe('a8 - exchange supports promises', function () {
     this.timeout(1500);
 
     this.mesh.exchange.component.promiseReturner({number: 1})
-
       .then(function (res) {
         res.should.eql({number: 2});
         done();
       })
-
-  });
-
-  it('supports returning a promise without wrapping it', function (done) {
-
-    this.timeout(1500);
-
-    var promise = this.mesh.exchange.component.promiseReturnAsIs({number: 1})
-
-    promise
-      .then(function (res) {
-        res.should.eql({number: 2});
-        done();
-      })
-      .catch(function(err){
-        done(err);
-      });
 
   });
 

--- a/test/a8-exchange-promises.js
+++ b/test/a8-exchange-promises.js
@@ -60,9 +60,14 @@ SeeAbove.prototype.promiseCaller = function (opts, callback) {
 
 };
 
-SeeAbove.prototype.promiseReturner = function (opts) {
+SeeAbove.prototype.promiseReturnerNoCallback = function (opts) {
   return this.promiseMethod(opts);
 };
+
+SeeAbove.prototype.promiseReturner = Promise.promisify(function (opts,callback) {
+  return this.promiseMethod(opts, callback);
+});
+
 
 SeeAbove.prototype.synchronousMethodHappnOrigin = function (opts, opts2, $happn, $origin) {
 
@@ -332,11 +337,23 @@ describe('a8 - exchange supports promises', function () {
 
   });
 
+  it('supports returning a promise from a method on the exchange with no callback', function (done) {
+
+    this.timeout(1500);
+
+    this.mesh.exchange.component.promiseReturnerNoCallback({number: 1})
+      .then(function (res) {
+        res.should.eql({number: 2});
+        done();
+      })
+
+  });
+
   it('supports returning a promise from a method on the exchange that throws an error', function (done) {
 
     this.timeout(1500);
 
-    this.mesh.exchange.component.promiseReturner({number: 1, errorAs: 'throw'})
+    this.mesh.exchange.component.promiseReturnerNoCallback({number: 1, errorAs: 'throw'})
       .then(function () {
         done(new Error('should not get here'));
       })
@@ -350,7 +367,7 @@ describe('a8 - exchange supports promises', function () {
 
     this.timeout(1500);
 
-    this.mesh.exchange.component.promiseReturner({number: 1, errorAs: 'callback'})
+    this.mesh.exchange.component.promiseReturnerNoCallback({number: 1, errorAs: 'callback'})
       .then(function () {
         done(new Error('should not get here'));
       })

--- a/test/a8-exchange-promises.js
+++ b/test/a8-exchange-promises.js
@@ -30,7 +30,7 @@ SeeAbove.prototype.promiseMethod = Promise.promisify(function (opts, callback) {
 SeeAbove.prototype.promisePromiseCaller = Promise.promisify(function (opts, callback) {
 
   this.promiseMethod(opts)
-    .then(function(){
+    .then(function () {
       callback(null, opts);
     })
     .catch(callback)
@@ -40,18 +40,22 @@ SeeAbove.prototype.promisePromiseCaller = Promise.promisify(function (opts, call
 SeeAbove.prototype.promiseCaller = function (opts, callback) {
 
   this.promiseMethod(opts)
-    .then(function(){
+    .then(function () {
       callback(null, opts);
     })
     .catch(callback)
 
 };
 
-SeeAbove.prototype.promiseReturner = Promise.promisify(function (opts,callback) {
+SeeAbove.prototype.promiseReturnAsIs = function (opts) {
+  return this.promiseMethod(opts);
+};
+
+SeeAbove.prototype.promiseReturner = Promise.promisify(function (opts, callback) {
   return this.promiseMethod(opts, callback);
 });
 
-SeeAbove.prototype.synchronousMethodHappnOrigin = function(opts, opts2, $happn, $origin){
+SeeAbove.prototype.synchronousMethodHappnOrigin = function (opts, opts2, $happn, $origin) {
 
   if (!$happn) throw new Error('$happn is meant to exist');
   if (!$origin) throw new Error('$origin is meant to exist');
@@ -59,7 +63,7 @@ SeeAbove.prototype.synchronousMethodHappnOrigin = function(opts, opts2, $happn, 
   return opts + opts2;
 };
 
-SeeAbove.prototype.synchronousMethod = function(opts, opts2){
+SeeAbove.prototype.synchronousMethod = function (opts, opts2) {
   return opts + opts2;
 };
 
@@ -310,6 +314,20 @@ describe('a8 - exchange supports promises', function () {
         res.should.eql({number: 2});
         done();
       })
+
+  });
+
+  it('supports returning a promise without wrapping it', function (done) {
+
+    this.timeout(1500);
+
+    var promise = this.mesh.exchange.component.promiseReturnAsIs({number: 1})
+      .then(function (res) {
+        res.should.eql({number: 2});
+        done();
+      });
+
+    return promise;
 
   });
 

--- a/test/a8-exchange-promises.js
+++ b/test/a8-exchange-promises.js
@@ -89,6 +89,9 @@ SeeAbove.prototype.$happner = {
           },
           'synchronousMethodHappnOrigin': {
             type: 'sync-promise'//NB - this is how you can wrap a synchronous method with a promise
+          },
+          'fireAndForget': {
+            type: 'sync'
           }
         }
       }

--- a/test/lib/1-consume-module.js
+++ b/test/lib/1-consume-module.js
@@ -113,7 +113,6 @@ describe('Consumes an external module', function () {
         // console.log('failure in init')
         // console.log(err.stack)
       }
-      ;
 
       done(err);
 


### PR DESCRIPTION
Fix #176 

Allow methods in modules to return a promise instead of call a callback.

On the mesh side it checks if the function returned a promise and will then wait for that promise to resolve to call the callback with the result (or error).

On the client side any function that is not specified as sync will create a callback handler and time out if the result is not returned in time.