### PR TITLE
release/1.23.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -397,3 +397,9 @@
 - fix for path sep in packager
 - added appveypr.yml
 - removed osx tests on travis
+
+1.23.0 2016-10-20
+-----------------
+
+- REST now able to GET from a remote method, passing params through the query string
+

--- a/lib/modules/rest/index.js
+++ b/lib/modules/rest/index.js
@@ -148,6 +148,13 @@ Rest.prototype.__parseBody = function (req, res, $happn, callback) {
 
   try{
 
+    if (req.method == 'GET'){
+
+      if (req.uri.query && req.uri.query.encoded_parameters) return callback(JSON.parse(decodeURIComponent( req.uri.query.encoded_parameters )));
+
+      return callback({parameters:req.uri.query});
+    }
+
     if (req.body) return callback(req.body);
 
     jsonBody(req, res, function(e, body){
@@ -159,6 +166,7 @@ Rest.prototype.__parseBody = function (req, res, $happn, callback) {
     });
 
   }catch(e){
+
     return _this.__respond($happn, "Failure parsing request body", null, e, res);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happner",
-  "version": "1.22.3",
+  "version": "1.23.0",
   "description": "distributed application engine with evented storage and mesh services",
   "main": "lib/mesh.js",
   "bin": {

--- a/test/e3a-rest-component.js
+++ b/test/e3a-rest-component.js
@@ -35,6 +35,11 @@ SeeAbove.prototype.method3 = function ($happn, $origin, opts, callback) {
   callback(null, opts);
 };
 
+SeeAbove.prototype.method4 = function ($happn, $origin, number, another, callback) {
+
+  callback(null, {product:parseInt(number) + parseInt(another)});
+};
+
 SeeAbove.prototype.synchronousMethod = function(opts, opts2){
   return opts + opts2;
 };
@@ -368,6 +373,39 @@ describe('e3a-rest-component', function () {
 
       expect(result.data.number).to.be(2);
 
+      done();
+    });
+
+  });
+
+  it('tests getting an operation from a local method with a simple parameter set', function(done){
+
+    var restClient = require('restler');
+
+    restClient.get('http://localhost:10000/rest/method/testComponent/method4?number=1&another=2').on('complete', function(result){
+
+      expect(result.data.product).to.be(3);
+      done();
+    });
+
+  });
+
+  it('tests getting an operation from a local method with a serialized parameter', function(done){
+
+    var restClient = require('restler');
+
+    var operation = {
+      parameters:{
+        "number":1,
+        "another":2
+      }
+    };
+
+    var encoded = encodeURIComponent(JSON.stringify(operation));
+
+    restClient.get('http://localhost:10000/rest/method/testComponent/method4?encoded_parameters=' + encoded).on('complete', function(result){
+
+      expect(result.data.product).to.be(3);
       done();
     });
 

--- a/test/e3b-rest-component-secure.js
+++ b/test/e3b-rest-component-secure.js
@@ -35,6 +35,12 @@ SeeAbove.prototype.method3 = function ($happn, $origin, opts, callback) {
   callback(null, opts);
 };
 
+SeeAbove.prototype.method4 = function ($happn, $origin, number, another, callback) {
+
+  callback(null, {product:parseInt(number) + parseInt(another)});
+};
+
+
 SeeAbove.prototype.synchronousMethod = function(opts, opts2){
   return opts + opts2;
 };
@@ -576,6 +582,51 @@ describe('e3b-rest-component-secure', function () {
     });
   });
 
+  it('tests getting an operation from a local method with a simple parameter set', function(done){
+
+    //TODO login function gives us a token, token is used in body of rest request
+
+    login(function(e, result){
+
+      if (e) return done(e);
+
+      var restClient = require('restler');
+
+      restClient.get('http://localhost:10000/rest/method/testComponent/method4?number=1&another=2&happn_token=' + result.data.token).on('complete', function(result){
+
+        expect(result.data.product).to.be(3);
+        done();
+      });
+
+    });
+  });
+
+  it('tests getting an operation from a local method with a serialized parameter', function(done){
+
+    login(function(e, result){
+
+      if (e) return done(e);
+
+      var restClient = require('restler');
+
+      var operation = {
+        parameters:{
+          "number":1,
+          "another":2
+        }
+      };
+
+      var encoded = encodeURIComponent(JSON.stringify(operation));
+
+      restClient.get('http://localhost:10000/rest/method/testComponent/method4?encoded_parameters=' + encoded + '&happn_token=' + result.data.token).on('complete', function(result){
+
+        expect(result.data.product).to.be(3);
+        done();
+      });
+
+    });
+  });
+
   it('tests posting an operation to the security component fails', function(done){
 
     //TODO login function gives us a token, token is used in body of rest request
@@ -691,7 +742,7 @@ describe('e3b-rest-component-secure', function () {
 
                 expect(result.data['/testComponent/method1']).to.not.be(null);
                 expect(result.data['/testComponent/method2']).to.be(undefined);
-                
+
                 expect(Object.keys(result.data).length).to.be(1);
 
                 var operation = {


### PR DESCRIPTION
allows REST RPC calls to be made using GET requests, passing the parameters in as query string arguments.