### PR TITLE
1.28.5 - fix REST crash when posting object without parameters to function using $restParams

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -473,3 +473,8 @@
 
 - fix #252, make meshClient disconnect() work for disconnected client
 
+
+1.28.5 2016-12-16
+-----------------
+
+- fix #257, fix REST crash when posting object without parameters to function using $restParams

--- a/lib/modules/rest/index.js
+++ b/lib/modules/rest/index.js
@@ -256,10 +256,13 @@ Rest.prototype.handleRequest = function (req, res, $happn, $origin) {
           }
 
           if (parameter.name == '$restParams') {
-            delete body.parameters.happn_token;
-            delete body.parameters.username;
-            delete body.parameters.password;
-            args.push(body.parameters);
+            if (body.parameters) {
+              delete body.parameters.happn_token;
+              delete body.parameters.username;
+              delete body.parameters.password;
+              args.push(body.parameters);
+            }
+            else args.push({});
             return;
           }
 
@@ -268,7 +271,7 @@ Rest.prototype.handleRequest = function (req, res, $happn, $origin) {
             return;
           }
 
-          if (body.parameters[parameter.name]) args.push(body.parameters[parameter.name]);
+          if (body.parameters && body.parameters[parameter.name]) args.push(body.parameters[parameter.name]);
           else args.push(null);
 
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happner",
-  "version": "1.28.4",
+  "version": "1.28.5",
   "description": "distributed application engine with evented storage and mesh services",
   "main": "lib/mesh.js",
   "bin": {

--- a/test/e3b-rest-component-secure.js
+++ b/test/e3b-rest-component-secure.js
@@ -562,6 +562,24 @@ describe('e3b-rest-component-secure', function () {
 
   });
 
+  it('tests posting an empty operation without parameters to a local method using $restParams', function(done){
+    login(function (e, result) {
+
+      if (e) return done(e);
+
+      var restClient = require('restler');
+
+      var operation = {
+      };
+
+      restClient.postJson('http://localhost:10000/rest/method/testComponent/method5?happn_token=' + result.data.token, operation).on('complete', function (result) {
+        expect(result.data.$origin.username).to.be('_ADMIN');
+        expect(result.data.$userSession.username).to.be('_ADMIN');
+        done();
+      });
+    });
+  });
+
   it('tests posting an operation to a local method', function (done) {
 
     login(function (e, result) {


### PR DESCRIPTION

fixes #257